### PR TITLE
fix copyright format error, don't export pa_ounit.syntax

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -5,7 +5,7 @@ Name:             async
 Version:          112.24.00
 Synopsis:         Jane Street Capital's asynchronous execution library
 Authors:          Jane Street Group, LLC <opensource@janestreet.com>
-Copyrights:       (C) 2008-2013 Jane Street Group, LLC <opensource@janestreet.com>
+Copyrights:       (C) 2008-2013 Jane Street Group LLC <opensource@janestreet.com>
 Maintainers:      Jane Street Group, LLC <opensource@janestreet.com>
 License:          Apache-2.0
 LicenseFile:      LICENSE.txt
@@ -36,6 +36,11 @@ Library async
                       async_extra,
                       pa_ounit,
                       pa_ounit.syntax,
+                      threads
+  XMETARequires:      async_kernel,
+                      async_unix,
+                      async_extra,
+                      pa_ounit,
                       threads
 
 # +-------------------------------------------------------------------+


### PR DESCRIPTION
This fixes a build error introduced by the new copyright format.

It also prevents `pa_ounit.syntax` from being an exported dependency (which will stop `camlp4` from being automatically loaded). I PR'ed a similar [change](https://github.com/janestreet/pa_test/commit/b8c104df1ea50f3dc1a130e1d17cb647c5112368) to pa_test. This is more of the same, essentially.
